### PR TITLE
Encode MARCOWeb 

### DIFF
--- a/experiments/dynamic_encode_clueweb_docs_minicpm.sh
+++ b/experiments/dynamic_encode_clueweb_docs_minicpm.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#SBATCH --job-name=marcoweb_minicpm
+#SBATCH --output=logs/%x-%j.out
+#SBATCH -e logs/%x-%j.err
+#SBATCH --partition=general
+#SBATCH --gres=gpu:L40S:1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=200G
+#SBATCH --time=2-00:00:00
+#SBATCH --array=0-7
+
+eval "$(conda shell.bash hook)"
+conda activate minicpmembed
+module load cuda-12.1
+
+set -o allexport
+source local.env
+set +o allexport
+
+echo $HF_HOME
+
+PATH_TO_CORPUS="/data/group_data/cx_group/ann_index/corpus/clueweb22/MARCO_Web/train-2"
+
+PATH_TO_MODEL=openbmb/MiniCPM-Embedding-Light
+
+EMBEDDING_OUTPUT_DIR=/data/group_data/cx_group/ann_index/embeds/clueweb/MiniCPM-Embedding-Light
+
+mkdir -p $EMBEDDING_OUTPUT_DIR
+
+shard=${SLURM_ARRAY_TASK_ID}
+    
+python -m tevatron.retriever.driver.encode \
+    --clueweb_api_dataset True \
+    --output_dir=$EMBEDDING_OUTPUT_DIR \
+    --bf16 \
+    --model_name_or_path $PATH_TO_MODEL \
+    --dataset_cache_dir $HF_HOME \
+    --cache_dir $HF_HOME \
+    --query_prefix "Instruction: Given a web search query, retrieve relevant passages that answer the query. Query: " \
+    --passage_prefix "" \
+    --pooling avg \
+    --normalize \
+    --per_device_eval_batch_size 300 \
+    --query_max_len 32 \
+    --passage_max_len 512 \
+    --dataset_path $PATH_TO_CORPUS \
+    --add_markers False \
+    --dataset_number_of_shards 8 \
+    --dataset_shard_index ${shard} \
+    --encode_output_path $EMBEDDING_OUTPUT_DIR/marcoweb-corpus-train-2.cweb.${shard}.pkl
+
+# train-1: 46879819
+# train-2: 43156792

--- a/tevatron/src/tevatron/retriever/arguments.py
+++ b/tevatron/src/tevatron/retriever/arguments.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass, field
 from typing import Optional
 from transformers import TrainingArguments
 
+from typing import List
+
 
 @dataclass
 class ModelArguments:
@@ -155,6 +157,11 @@ class DataArguments:
     )
 
 
+@dataclass 
+class TevatronDataArguments(DataArguments): 
+    clueweb_api_dataset: bool = field(default=False, metadata={"help": "Whether this dataset needs clueweb api for dynamic generation"})
+    langs: List[str] = field(default_factory=lambda: ["de", "en", "es", "fr", "it", "ja", "nl", "other", "pl", "pt", "zh_chs"], metadata={"help": "Languages to process for the clueweb api"})
+
 @dataclass
 class TevatronTrainingArguments(TrainingArguments):
     warmup_ratio: float = field(default=0.1)
@@ -162,3 +169,4 @@ class TevatronTrainingArguments(TrainingArguments):
     grad_cache: bool = field(default=False, metadata={"help": "Use gradient cache update"})
     gc_q_chunk_size: int = field(default=4)
     gc_p_chunk_size: int = field(default=32)
+

--- a/tevatron/src/tevatron/retriever/driver/encode.py
+++ b/tevatron/src/tevatron/retriever/driver/encode.py
@@ -15,9 +15,10 @@ from transformers import (
     HfArgumentParser,
 )
 
-from tevatron.retriever.arguments import ModelArguments, DataArguments, \
+from tevatron.retriever.arguments import ModelArguments, \
+    TevatronDataArguments as DataArguments, \
     TevatronTrainingArguments as TrainingArguments
-from tevatron.retriever.dataset import EncodeDataset
+from tevatron.retriever.dataset import EncodeDataset, EncodeDataset_MARCOWeb
 from tevatron.retriever.collator import EncodeCollator
 from tevatron.retriever.modeling import EncoderOutput, DenseModel
 
@@ -69,7 +70,12 @@ def main():
         torch_dtype=torch_dtype
     )
 
-    encode_dataset = EncodeDataset(
+    if data_args.clueweb_api_dataset: 
+        dataset_obj = EncodeDataset_MARCOWeb
+    else: 
+        dataset_obj = EncodeDataset
+        
+    encode_dataset = dataset_obj(
         data_args=data_args,
     )
 

--- a/tevatron/src/tevatron/utils/ClueWeb22Api.py
+++ b/tevatron/src/tevatron/utils/ClueWeb22Api.py
@@ -1,0 +1,63 @@
+import os
+import gzip
+
+
+class ClueWeb22Api:
+    """
+    ClueWeb22Api adapted from source: https://github.com/lemurproject/ClueWeb22/blob/main/ClueWeb22Api.py
+    This version adpated to the specific file layout for the processed MARCOWeb corpus: e.g. MARCO_Web/train-2/de/de-00.json.gz
+    """
+
+    def __init__(self, cw22id, cw22root_path):
+        self.cw22id = cw22id
+        self.cw22root_path = cw22root_path
+
+    def get_marcoweb_clean_text(self):
+            record = self.get_marcoweb_json_record('txt')
+            return record
+    
+    def get_base_filename(self, cw22id):
+        html_path = self.cw22root_path + os.sep 
+        id_parts = cw22id.split('-') # "clueweb22-en-{jjsongz_id}-{ddoc_id}"
+        language = id_parts[1]
+        base_path = html_path + os.sep + language + os.sep 
+        base_filename = base_path + id_parts[1] + '-' + id_parts[2]
+        return base_filename
+        
+    def get_marcoweb_json_record(self, record_type="txt"):
+        cw22id = self.cw22id 
+        # custom file path 
+        base_filename = self.get_base_filename(cw22id)
+        json_path = base_filename + '.json.gz'
+        offset_path = base_filename + '.offset'
+
+        id_parts = cw22id.split('-')
+        doc = int(id_parts[len(id_parts) - 1])
+
+        offset_length = len('{:010d}\n'.format(0, 0))
+        with open (json_path,'rb') as f_json:
+            with open (offset_path, 'r') as f_offset:
+                f_offset.seek(int(doc) * int(offset_length))
+                start_bytes = int (f_offset.read (offset_length).strip())
+                end_bytes =   int (f_offset.read (offset_length).strip())
+                f_json.seek(start_bytes)
+                record = f_json.read(end_bytes - start_bytes)
+                record = gzip.decompress(record).decode('utf-8')
+                return record
+
+# Create shard for the specific dataset 
+def create_shards(data, num_shards, index):
+    if not isinstance(data, list):
+        raise ValueError("Input data must be a list.")
+
+    # Compute shard size
+    shard_size = len(data) // num_shards
+    
+    start_index = index * shard_size
+    if index == num_shards - 1: 
+        # final shard handle the residuals 
+        end_index = len(data)
+    else: 
+        end_index = start_index + shard_size
+
+    return data[start_index:end_index]


### PR DESCRIPTION
Configure the option to encode the train corpus of [MSMARCO Web Search](https://github.com/microsoft/MS-MARCO-Web-Search?tab=readme-ov-file#100m-dataset) processed by Jamie. 

Corpus is dynamically computed by an adapted version of [ClueWeb22Api](https://github.com/lemurproject/ClueWeb22/blob/main/ClueWeb22Api.py). 

Shell script included in `experiments/dynamic_encode_clueweb_docs_minicpm.sh`. 
Mode enabled by setting `--clueweb_api_dataset True ` and the language subsets available by the default `--langs` in `tevatron/src/tevatron/retriever/arguments.py`. 

TODO: process the query dataset and enable query loading of the same routine.

 