### PR TITLE
Enable Checkpoints for Inference 

### DIFF
--- a/experiments/dynamic_encode_clueweb_docs_minicpm.sh
+++ b/experiments/dynamic_encode_clueweb_docs_minicpm.sh
@@ -2,12 +2,13 @@
 #SBATCH --job-name=marcoweb_minicpm
 #SBATCH --output=logs/%x-%j.out
 #SBATCH -e logs/%x-%j.err
-#SBATCH --partition=general
-#SBATCH --gres=gpu:L40S:1
+#SBATCH --partition=preempt  
+#SBATCH --gres=gpu:A6000:1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=200G
 #SBATCH --time=2-00:00:00
-#SBATCH --array=0-7
+#SBATCH --array=0-15
+
 
 eval "$(conda shell.bash hook)"
 conda activate minicpmembed
@@ -28,6 +29,9 @@ EMBEDDING_OUTPUT_DIR=/data/group_data/cx_group/ann_index/embeds/clueweb/MiniCPM-
 mkdir -p $EMBEDDING_OUTPUT_DIR
 
 shard=${SLURM_ARRAY_TASK_ID}
+echo $shard
+
+local_bz=2048
     
 python -m tevatron.retriever.driver.encode \
     --clueweb_api_dataset True \
@@ -40,14 +44,14 @@ python -m tevatron.retriever.driver.encode \
     --passage_prefix "" \
     --pooling avg \
     --normalize \
-    --per_device_eval_batch_size 300 \
+    --per_device_eval_batch_size $local_bz \
     --query_max_len 32 \
     --passage_max_len 512 \
     --dataset_path $PATH_TO_CORPUS \
     --add_markers False \
-    --dataset_number_of_shards 8 \
+    --dataset_number_of_shards 16 \
     --dataset_shard_index ${shard} \
+    --inference_save_step 20 \
     --encode_output_path $EMBEDDING_OUTPUT_DIR/marcoweb-corpus-train-2.cweb.${shard}.pkl
 
-# train-1: 46879819
 # train-2: 43156792

--- a/tevatron/src/tevatron/retriever/arguments.py
+++ b/tevatron/src/tevatron/retriever/arguments.py
@@ -169,4 +169,5 @@ class TevatronTrainingArguments(TrainingArguments):
     grad_cache: bool = field(default=False, metadata={"help": "Use gradient cache update"})
     gc_q_chunk_size: int = field(default=4)
     gc_p_chunk_size: int = field(default=32)
+    inference_save_step: int = field(default=50)
 


### PR DESCRIPTION
Checkpoint the output embeddings for inference in `tevatron/src/tevatron/retriever/driver/encode.py`. 
Save step enabled by `--inference_save_step`, defaults to 50. 
